### PR TITLE
Provide more compatibility with essentials

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -12,7 +12,7 @@ commands:
            /<command> - Open last person's inventory
            /<command> <Player> - Open a player's inventory
   openender:
-    aliases: [oe, enderchest]
+    aliases: [oe]
     description: Opens the enderchest of a player
     usage: |
            /<command> <Player> - Opens a player's enderchest


### PR DESCRIPTION
Since essentials conflict with this alias, i think it would be better this way. After all you can always use /oe which is a lot shorter than /enderchest :)
