### PR TITLE
Null pointer check

### DIFF
--- a/src/com/lishid/openinv/internal/v1_7_R4/PlayerDataManager.java
+++ b/src/com/lishid/openinv/internal/v1_7_R4/PlayerDataManager.java
@@ -80,11 +80,13 @@ public class PlayerDataManager implements IPlayerDataManager {
         OfflinePlayer[] offlinePlayers = Bukkit.getOfflinePlayers();
         for (OfflinePlayer player : offlinePlayers) {
             String name = player.getName();
-            if (name == null)
+           
+            if (name == null){
                 continue;
-            if (name.equalsIgnoreCase(search))
+            }
+            if (name.equalsIgnoreCase(search)){
                 return player.getUniqueId();
-
+            }
             if (name.toLowerCase().startsWith(lowerSearch)) {
                 int curDelta = name.length() - lowerSearch.length();
                 if (curDelta < delta) {


### PR DESCRIPTION
Players who haven't joined your server since the UUID conversion will have a null name. As a result, if you try to /openinv a player who _has_ joined your server since then, the loop can break due to a NPE while checking other players. This null check should fix that problem.
