### PR TITLE
Fix trapped chests linking with ordinary chests, instead of trapped ones

### DIFF
--- a/src/main/java/com/lishid/openinv/internal/v1_8_R1/AnySilentChest.java
+++ b/src/main/java/com/lishid/openinv/internal/v1_8_R1/AnySilentChest.java
@@ -90,7 +90,8 @@ public class AnySilentChest implements IAnySilentChest {
             return true;
         }
 
-        BlockChest chest = (BlockChest) Block.getByName("chest");
+        BlockChest chest = (BlockChest) (((BlockChest) world.getType(position).getBlock()).b == 1 ?
+                Block.getByName("trapped_chest") : Block.getByName("chest"));
 
         TileEntity tileEntity = world.getTileEntity(position);
         if (!(tileEntity instanceof TileEntityChest)) {

--- a/src/main/java/com/lishid/openinv/internal/v1_8_R1/AnySilentChest.java
+++ b/src/main/java/com/lishid/openinv/internal/v1_8_R1/AnySilentChest.java
@@ -35,7 +35,8 @@ public class AnySilentChest implements IAnySilentChest {
         BlockPosition position = new BlockPosition(x, y, z);
         EntityPlayer player = ((CraftPlayer) p).getHandle();
         World world = player.world;
-        BlockChest chest = (BlockChest) Block.getByName("chest");
+        BlockChest chest = (BlockChest) (((BlockChest) world.getType(position).getBlock()).b == 1 ?
+                Block.getByName("trapped_chest") : Block.getByName("chest"));
 
         // If block on top
         if (topBlocking(world, position)) {


### PR DESCRIPTION
The id->name block identification scheme change in Minecraft was reflected in the latest version of OpenInv: the block type, used for checking chest linking is no longer identified as the numerical ID of the block in question, but instead as a BlockChest type variable, which is always got as Block.getByName("chest"). This behavior ignored Trapped Chests in the check, and so linked both ordinary and trapped chests with ordinary ones. This caused a problem: if a trapped chest stands between two ordinary ones, it links with both of them, so the player gets a corrupt inventory view, reflecting contents of both three chests.
To fix this, BlockChest variable actually needs to reflect the type of the chest in question, so that it will appropriately link chest types.
The problem can easily be illustrated with the following screenshots:
1) Initial appearance of chest views (reflecting possible link situations):
![2015-01-13_21 40 59](https://cloud.githubusercontent.com/assets/4984813/5728052/1a922f50-9b70-11e4-9f71-732617a4079e.png)
![2015-01-13_21 41 02](https://cloud.githubusercontent.com/assets/4984813/5728055/1ac6f06e-9b70-11e4-82a0-6b4086b5f5ed.png)
![2015-01-13_21 41 07](https://cloud.githubusercontent.com/assets/4984813/5728053/1ac10de8-9b70-11e4-8f0c-427c65e91d9d.png)
![2015-01-13_21 41 33](https://cloud.githubusercontent.com/assets/4984813/5728054/1ac43748-9b70-11e4-86df-229ba7ad113f.png)

2) Same chest views as of this commit:
![2015-01-13_21 42 14](https://cloud.githubusercontent.com/assets/4984813/5728002/c153b03a-9b6f-11e4-8c2c-64f6237f2864.png)
![2015-01-13_21 42 17](https://cloud.githubusercontent.com/assets/4984813/5728004/c1890e88-9b6f-11e4-9062-2d92943fd579.png)
![2015-01-13_21 42 20](https://cloud.githubusercontent.com/assets/4984813/5728005/c18c18b2-9b6f-11e4-970a-d006abe94f22.png)
![2015-01-13_21 42 22](https://cloud.githubusercontent.com/assets/4984813/5728003/c188eb1a-9b6f-11e4-86ea-d70e833b321e.png)
