### PR TITLE
Add permission for online/offline opening (Resolves #129)

### DIFF
--- a/plugin/src/main/java/com/lishid/openinv/commands/OpenInvCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/OpenInvCommand.java
@@ -104,10 +104,20 @@ public class OpenInvCommand implements TabExecutor {
         boolean online = target.isOnline();
 
         if (!online) {
-            // Try loading the player's data
-            onlineTarget = this.plugin.loadPlayer(target);
+            if (Permissions.OPENOFFLINE.hasPermission(player)) {
+                // Try loading the player's data
+                onlineTarget = this.plugin.loadPlayer(target);
+            } else {
+                plugin.sendMessage(player, "messages.error.permissionPlayerOffline");
+                return;
+            }
         } else {
-            onlineTarget = target.getPlayer();
+            if (Permissions.OPENONLINE.hasPermission(player)) {
+                onlineTarget = target.getPlayer();
+            } else {
+                plugin.sendMessage(player, "messages.error.permissionPlayerOnline");
+                return;
+            }
         }
 
         if (onlineTarget == null) {

--- a/plugin/src/main/java/com/lishid/openinv/util/Permissions.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/Permissions.java
@@ -33,7 +33,9 @@ public enum Permissions {
     SEARCH("search"),
     EDITINV("editinv"),
     EDITENDER("editender"),
-    OPENSELF("openself");
+    OPENSELF("openself"),
+    OPENONLINE("openonline"),
+    OPENOFFLINE("openoffline");
 
     private final String permission;
 

--- a/plugin/src/main/resources/en_us.yml
+++ b/plugin/src/main/resources/en_us.yml
@@ -9,6 +9,8 @@ messages:
     permissionEnderAll: '&cYou''re not allowed to access other players'' ender chests.'
     permissionExempt: '&c%target%''s inventory is protected.'
     permissionCrossWorld: '&c%target% is not in your world.'
+    permissionPlayerOnline: '&cYou''re not allowed to open the inventory of online players.'
+    permissionPlayerOffline: '&cYou''re not allowed to open the inventory of offline players.'
     commandException: '&cAn error occurred. Please check console for details.'
   info:
     containerBlocked: 'You are opening a blocked container.'

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -25,6 +25,8 @@ permissions:
       OpenInv.anychest: true
       OpenInv.searchenchant: true
       OpenInv.searchcontainer: true
+      OpenInv.openonline: true
+      OpenInv.openoffline: true
 
 commands:
   openinv:

--- a/plugin/src/main/resources/pt_br.yml
+++ b/plugin/src/main/resources/pt_br.yml
@@ -9,6 +9,8 @@ messages:
     permissionEnderAll: '&cVoce nao tem permissao para abrir baus de ender de outros jogadores.'
     permissionExempt: '&cO inventario de %target% e protegido.'
     permissionCrossWorld: '&c%target% nao esta no seu mundo.'
+    permissionPlayerOnline: '&cVoce nao tem permissao para abrir o inventario de jogadores online.'
+    permissionPlayerOffline: '&cVoce nao tem permissao para abrir o inventario de jogadores offline.'
     commandException: '&cUm erro ocorreu. Por favor cheque o console para detalhes.'
   info:
     containerBlocked: 'Voce esta abrindo um recipiente bloqueado.'


### PR DESCRIPTION
This adds permissions for opening the inventories/enderchests of online and offline players separately. Not being allowed to open offline players also prevents any of the non-API player data loading but not the checking if the OfflinePlayer exists.