### PR TITLE
Add support for InvUnload

### DIFF
--- a/plugin/src/main/java/com/lishid/openinv/listeners/PlayerListener.java
+++ b/plugin/src/main/java/com/lishid/openinv/listeners/PlayerListener.java
@@ -55,8 +55,8 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
 
-        // Do not cancel the event if it is the InvUnloadCheckAccessEvent
-        if(!event.getClass().getName().equals("de.jeff_media.InvUnload.API.InvUnloadCheckAccessEvent")) {
+        // Do not cancel 3rd party plugins' custom events
+        if (!PlayerInteractEvent.class.equals(event.getClass())) {
             return;
         }
 

--- a/plugin/src/main/java/com/lishid/openinv/listeners/PlayerListener.java
+++ b/plugin/src/main/java/com/lishid/openinv/listeners/PlayerListener.java
@@ -54,6 +54,12 @@ public class PlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
+
+        // Do not cancel the event if it is the InvUnloadCheckAccessEvent
+        if(!event.getClass().getName().equals("de.jeff_media.InvUnload.API.InvUnloadCheckAccessEvent")) {
+            return;
+        }
+
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getPlayer().isSneaking()
                 || event.useInteractedBlock() == Result.DENY || event.getClickedBlock() == null
                 || !plugin.getAnySilentContainer().isAnySilentContainer(event.getClickedBlock())) {


### PR DESCRIPTION
~~This will check if the PlayerInteractEvent is an instance of InvUnload's custom event extending the PlayerInteractEvent. If yes, the listener immediately exists, because it doesn't have to do anything.~~

~~This is checked by using Event#getClass#getName, so that no dependencies need to be added. It has no downsides at all, so it would be nice if you could consider merging this PR.~~

This will not cancel 3rd party plugins' events that extend PlayerInteractEvent.

This fixes #144 